### PR TITLE
miscellaneous small stuff

### DIFF
--- a/art.c
+++ b/art.c
@@ -841,10 +841,10 @@ static int write_pcm_wav_header (FILE *outfile, int bps, int num_channels, unsig
         wavhdr.FormatTag = WAVE_FORMAT_EXTENSIBLE;
         wavhdr.BitsPerSample = bps;
         wavhdr.GUID [4] = 0x10;
-        wavhdr.GUID [6] = 0x80;
-        wavhdr.GUID [9] = 0xaa;
+        wavhdr.GUID [6] = '\x80';
+        wavhdr.GUID [9] = '\xaa';
         wavhdr.GUID [11] = 0x38;
-        wavhdr.GUID [12] = 0x9b;
+        wavhdr.GUID [12] = '\x9b';
         wavhdr.GUID [13] = 0x71;
     }
 

--- a/art.c
+++ b/art.c
@@ -60,8 +60,7 @@ static double phase_shift, gain = 1.0;
 
 int main (argc, argv) int argc; char **argv;
 {
-    int overwrite = 0;
-    int res;
+    int overwrite = 0, res;
     char *infilename = NULL, *outfilename = NULL;
     FILE *outfile;
 
@@ -294,7 +293,7 @@ typedef struct {
     } Samples;
     int32_t ChannelMask;
     uint16_t SubFormat;
-    char GUID [14];
+    unsigned char GUID [14];
 } WaveHeader;
 
 #define WaveHeaderFormat "SSLLSSSSLS"
@@ -841,10 +840,10 @@ static int write_pcm_wav_header (FILE *outfile, int bps, int num_channels, unsig
         wavhdr.FormatTag = WAVE_FORMAT_EXTENSIBLE;
         wavhdr.BitsPerSample = bps;
         wavhdr.GUID [4] = 0x10;
-        wavhdr.GUID [6] = '\x80';
-        wavhdr.GUID [9] = '\xaa';
+        wavhdr.GUID [6] = 0x80;
+        wavhdr.GUID [9] = 0xaa;
         wavhdr.GUID [11] = 0x38;
-        wavhdr.GUID [12] = '\x9b';
+        wavhdr.GUID [12] = 0x9b;
         wavhdr.GUID [13] = 0x71;
     }
 

--- a/art.c
+++ b/art.c
@@ -61,6 +61,7 @@ static double phase_shift, gain = 1.0;
 int main (argc, argv) int argc; char **argv;
 {
     int overwrite = 0;
+    int res;
     char *infilename = NULL, *outfilename = NULL;
     FILE *outfile;
 
@@ -260,7 +261,7 @@ int main (argc, argv) int argc; char **argv;
         return -1;
     }
 
-    int res = wav_process (infilename, outfilename);
+    res = wav_process (infilename, outfilename);
 
     free (infilename);
     free (outfilename);
@@ -313,6 +314,7 @@ static int wav_process (char *infilename, char *outfilename)
 {
     int format = 0, res = 0, inbits = 0, num_channels = 0;
     unsigned long num_samples = 0, sample_rate = 0;
+    unsigned int output_samples;
     uint32_t channel_mask = 0;
     FILE *infile, *outfile;
     RiffChunkHeader riff_chunk_header;
@@ -525,7 +527,7 @@ static int wav_process (char *infilename, char *outfilename)
         return -1;
     }
 
-    unsigned int output_samples = process_audio (infile, outfile, sample_rate, num_samples, num_channels, inbits);
+    output_samples = process_audio (infile, outfile, sample_rate, num_samples, num_channels, inbits);
 
     // write an extra padding zero byte if the data chunk is not an even size
 
@@ -559,6 +561,7 @@ static unsigned int process_audio (FILE *infile, FILE *outfile, unsigned long sa
     int samples_to_append = 0, pre_filter = 0, post_filter = 0;
     Biquad *lowpass1 = NULL, *lowpass2 = NULL;
     int flags = SUBSAMPLE_INTERPOLATE;
+    uint32_t progress_divider = 0, percent;
     BiquadCoefficients lowpass_coeff;
     unsigned char *tmpbuffer = NULL;
     void *readbuffer = inbuffer;
@@ -637,10 +640,12 @@ static unsigned int process_audio (FILE *infile, FILE *outfile, unsigned long sa
     }
 
     if (pre_filter || post_filter) {
+        int  i;
+
         lowpass1 = calloc (num_channels, sizeof (Biquad));
         lowpass2 = calloc (num_channels, sizeof (Biquad));
 
-        for (int i = 0; i < num_channels; ++i) {
+        for (i = 0; i < num_channels; ++i) {
             biquad_init (lowpass1 + i, &lowpass_coeff, 1.0);
             biquad_init (lowpass2 + i, &lowpass_coeff, 1.0);
         }
@@ -667,8 +672,6 @@ static unsigned int process_audio (FILE *infile, FILE *outfile, unsigned long sa
     // this takes care of the filter delay and any user-specified phase shift
     if (resampler)
         resampleAdvancePosition (resampler, num_taps / 2.0 + phase_shift);
-
-    uint32_t progress_divider = 0, percent;
 
     if (verbosity >= 0 && remaining_samples > 1000) {
         progress_divider = (remaining_samples + 50) / 100;
@@ -716,20 +719,24 @@ static unsigned int process_audio (FILE *infile, FILE *outfile, unsigned long sa
                 }
             }
 
-            if (gain != 1.0)
-                for (int i = 0; i < samples_read * num_channels; ++i)
+            if (gain != 1.0) {
+                int  i;
+                for (i = 0; i < samples_read * num_channels; ++i)
                     inbuffer [i] *= gain;
+            }
         }
         else
             floatIntegersLE (tmpbuffer, gain, inbits, (inbits + 7) / 8, 1, inbuffer, samples_read * num_channels);
 
         // common code to process the audio in 32-bit floats
 
-        if (pre_filter)
-            for (int i = 0; i < num_channels; ++i) {
+        if (pre_filter) {
+            int  i;
+            for (i = 0; i < num_channels; ++i) {
                 biquad_apply_buffer (lowpass1 + i, inbuffer + i, samples_read, num_channels);
                 biquad_apply_buffer (lowpass2 + i, inbuffer + i, samples_read, num_channels);
             }
+        }
 
         if (resampler) {
             res = resampleProcessInterleaved (resampler, inbuffer, samples_read, outbuffer, outbuffer_samples, sample_ratio);
@@ -740,11 +747,13 @@ static unsigned int process_audio (FILE *infile, FILE *outfile, unsigned long sa
             samples_generated = samples_read;
         }
 
-        if (post_filter)
-            for (int i = 0; i < num_channels; ++i) {
+        if (post_filter) {
+            int  i;
+            for (i = 0; i < num_channels; ++i) {
                 biquad_apply_buffer (lowpass1 + i, outbuffer + i, samples_generated, num_channels);
                 biquad_apply_buffer (lowpass2 + i, outbuffer + i, samples_generated, num_channels);
             }
+        }
 
         // finally write the audio, converting to appropriate integer format if requested
 

--- a/decimator.c
+++ b/decimator.c
@@ -218,10 +218,11 @@ void decimateFree (Decimate *cxt)
 static inline double tpdf_dither (uint32_t *generator, int type)
 {
     uint32_t random = *generator;
+    uint32_t first ;
 
     random = ((random << 4) - random) ^ 1;
     random = ((random << 4) - random) ^ 1;
-    uint32_t first = type ? *generator ^ ((int32_t) type >> 31) : ~random;
+    first = type ? *generator ^ ((int32_t) type >> 31) : ~random;
     random = ((random << 4) - random) ^ 1;
     random = ((random << 4) - random) ^ 1;
     *generator = random = ((random << 4) - random) ^ 1;

--- a/decimator.c
+++ b/decimator.c
@@ -217,8 +217,7 @@ void decimateFree (Decimate *cxt)
 
 static inline double tpdf_dither (uint32_t *generator, int type)
 {
-    uint32_t random = *generator;
-    uint32_t first ;
+    uint32_t random = *generator, first;
 
     random = ((random << 4) - random) ^ 1;
     random = ((random << 4) - random) ^ 1;
@@ -226,6 +225,7 @@ static inline double tpdf_dither (uint32_t *generator, int type)
     random = ((random << 4) - random) ^ 1;
     random = ((random << 4) - random) ^ 1;
     *generator = random = ((random << 4) - random) ^ 1;
+
     return (((first >> 1) + (random >> 1)) / 2147483648.0) - 1.0;
 }
 
@@ -239,7 +239,7 @@ static void shaper_init (Biquad *f, float a0, float a1, float a2, float a3, floa
     BiquadCoefficients coeffs = { 0 };
 
     if (a0 != 1.0) {
-        fprintf (stderr, "shaper_init() error: a0 = %g, should be zero!\n", a0);
+        fprintf (stderr, "shaper_init() error: a0 = %g, should be one!\n", a0);
         exit (1);
     }
 

--- a/resampler.c
+++ b/resampler.c
@@ -423,12 +423,11 @@ static double apply_filter(float* A, float* B, int num_taps)
 
 static void init_filter (Resample *cxt, float *filter, double fraction, double lowpass_ratio)
 {
+    double filter_sum = 0.0, scaler, error;
     const double a0 = 0.35875;
     const double a1 = 0.48829;
     const double a2 = 0.14128;
     const double a3 = 0.01168;
-    double filter_sum = 0.0;
-    double scaler, error = 0.0;
     int i;
 
     // "dist" is the absolute distance from the sinc maximum to the filter tap to be calculated, in radians

--- a/resampler.c
+++ b/resampler.c
@@ -428,6 +428,7 @@ static void init_filter (Resample *cxt, float *filter, double fraction, double l
     const double a2 = 0.14128;
     const double a3 = 0.01168;
     double filter_sum = 0.0;
+    double scaler, error = 0.0;
     int i;
 
     // "dist" is the absolute distance from the sinc maximum to the filter tap to be calculated, in radians
@@ -457,7 +458,8 @@ static void init_filter (Resample *cxt, float *filter, double fraction, double l
 
     // filter should have unity DC gain
 
-    double scaler = 1.0 / filter_sum, error = 0.0;
+    scaler = 1.0 / filter_sum;
+    error = 0.0;
 
     for (i = cxt->numTaps / 2; i < cxt->numTaps; i = cxt->numTaps - i - (i >= cxt->numTaps / 2)) {
         filter [i] = (cxt->tempFilter [i] *= scaler) - error;


### PR DESCRIPTION
- art.c (write_pcm_wav_header): avoid constant value truncation warnings.
  E.g. those C4310 from MSVC or W106 from Watcom.

- make it build using C90 compilers
  i.e. eliminate lazy declarations and for loop initial declarations.

Pick as you like.

